### PR TITLE
Rename "Narrator" to "Toggle Narrator"

### DIFF
--- a/src/main/resources/assets/rebind/lang/en_US.lang
+++ b/src/main/resources/assets/rebind/lang/en_US.lang
@@ -2,7 +2,7 @@ key.quit=Quit
 key.hideHUD=Hide HUD
 key.debugScreen=Debug Screen
 key.switchShader=Switch Shader
-key.narrator=Narrator
+key.narrator=Toggle Narrator
 
 rebind.command.help.title=Available commands:
 rebind.command.help.list=show list of unknown keybindings


### PR DESCRIPTION
I think this would be more consistent with the vanilla keybinds:
![image](https://user-images.githubusercontent.com/16755704/55274837-245ba700-5331-11e9-9722-801737ac1c65.png)
